### PR TITLE
allow carry > 1 in add_to_data_length().

### DIFF
--- a/picosha2.h
+++ b/picosha2.h
@@ -251,8 +251,8 @@ private:
 		for(std::size_t i = 0; i < 4; ++i) {
 			data_length_digits_[i] += carry;
 			if(data_length_digits_[i] >= 65536u) {
-				data_length_digits_[i] -= 65536u;
-				carry = 1;
+				carry = data_length_digits_[i]>>16;
+				data_length_digits_[i] &= 65535u;
 			}
 			else {
 				break;


### PR DESCRIPTION
Maintain 16 bit segments. Unlikely to cause error unless doing multi-GB lengths in chunks >= 65536*2.
(Noticed in code review when rewriting to straight C.)