### PR TITLE
refactoring: magic-number 32 is replaced with KDigestSize constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ PicoSHA2 is a tiny SHA256 hash generator for C++ with following properties:
 // any STL sequantial container (vector, list, dequeue...)
 std::string src_str = "The quick brown fox jumps over the lazy dog";
 
-std::vector<unsigned char> hash(32);
+std::vector<unsigned char> hash(picosha2::KDigestSize);
 picosha2::hash256(src_str.begin(), src_str.end(), hash.begin(), hash.end());
 
 std::string hex_str = picosha2::bytes_to_hex_string(hash.begin(), hash.end());
@@ -32,7 +32,7 @@ hasher.process(block.begin(), block.end());
 ...
 hasher.finish();
 
-std::vector<unsigned char> hash(32);
+std::vector<unsigned char> hash(picosha2::KDigestSize);
 hasher.get_hash_bytes(hash.begin(), hash.end());
 
 std::string hex_str = picosha2::get_hash_hex_string(hasher);
@@ -44,7 +44,7 @@ The file `example/interactive_hasher.cpp` has more detailed information.
 
 ```c++
 std::ifstream ifs("file.txt", std::ios::binary);
-std::vector<unsigned char> hash(32);
+std::vector<unsigned char> hash(picosha2::KDigestSize);
 picosha2::hash256(std::istreambuf_iterator<char>(ifs), std::istreambuf_iterator<char>(), hash.begin(), hash.end());
 ```
 
@@ -88,14 +88,14 @@ std::string hash_hex_str = picosha2::hash256_hex_string(src_vect);
 ```
 
 ```c++
-unsigned char src_c_array[32] = {...};
+unsigned char src_c_array[picosha2::KDigestSize] = {...};
 std::string hash_hex_str;
-picosha2::hash256_hex_string(src_c_array, src_c_array+32, hash_hex_str);
+picosha2::hash256_hex_string(src_c_array, src_c_array+picosha2::KDigestSize, hash_hex_str);
 ```
 
 ```c++
-unsigned char src_c_array[32] = {...};
-std::string hash_hex_str = picosha2::hash256_hex_string(src_c_array, src_c_array+32);
+unsigned char src_c_array[picosha2::KDigestSize] = {...};
+std::string hash_hex_str = picosha2::hash256_hex_string(src_c_array, src_c_array+picosha2::KDigestSize);
 ```
 
 
@@ -106,7 +106,7 @@ std::string hash_hex_str = picosha2::hash256_hex_string(src_c_array, src_c_array
 std::string src_str = "The quick brown fox jumps over the lazy dog";
 
 //any STL sequantial containers (vector, list, dequeue...)
-std::vector<unsigned char> hash(32);
+std::vector<unsigned char> hash(picosha2::KDigestSize);
 
 // in: container, out: container
 picosha2::hash256(src_str, hash);
@@ -117,7 +117,7 @@ picosha2::hash256(src_str, hash);
 std::string src_str = "The quick brown fox jumps over the lazy dog";
 
 //any STL sequantial containers (vector, list, dequeue...)
-std::vector<unsigned char> hash(32);
+std::vector<unsigned char> hash(picosha2::KDigestSize);
 
 // in: iterator pair, out: contaner
 picosha2::hash256(src_str.begin(), src_str.end(), hash);
@@ -125,14 +125,14 @@ picosha2::hash256(src_str.begin(), src_str.end(), hash);
 
 ```c++
 std::string src_str = "The quick brown fox jumps over the lazy dog";
-unsigned char hash_byte_c_array[32];
+unsigned char hash_byte_c_array[picosha2::KDigestSize];
 // in: container, out: iterator(pointer) pair
-picosha2::hash256(src_str, hash_byte_c_array, hash_byte_c_array+32);
+picosha2::hash256(src_str, hash_byte_c_array, hash_byte_c_array+picosha2::KDigestSize);
 ```
 
 ```c++
 std::string src_str = "The quick brown fox jumps over the lazy dog";
-std::vector<unsigned char> hash(32);
+std::vector<unsigned char> hash(picosha2::KDigestSize);
 // in: iterator pair, out: iterator pair
 picosha2::hash256(src_str.begin(), src_str.end(), hash.begin(), hash.end());
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ PicoSHA2 is a tiny SHA256 hash generator for C++ with following properties:
 // any STL sequantial container (vector, list, dequeue...)
 std::string src_str = "The quick brown fox jumps over the lazy dog";
 
-std::vector<unsigned char> hash(picosha2::KDigestSize);
+std::vector<unsigned char> hash(picosha2::k_digest_size);
 picosha2::hash256(src_str.begin(), src_str.end(), hash.begin(), hash.end());
 
 std::string hex_str = picosha2::bytes_to_hex_string(hash.begin(), hash.end());
@@ -32,7 +32,7 @@ hasher.process(block.begin(), block.end());
 ...
 hasher.finish();
 
-std::vector<unsigned char> hash(picosha2::KDigestSize);
+std::vector<unsigned char> hash(picosha2::k_digest_size);
 hasher.get_hash_bytes(hash.begin(), hash.end());
 
 std::string hex_str = picosha2::get_hash_hex_string(hasher);
@@ -44,7 +44,7 @@ The file `example/interactive_hasher.cpp` has more detailed information.
 
 ```c++
 std::ifstream ifs("file.txt", std::ios::binary);
-std::vector<unsigned char> hash(picosha2::KDigestSize);
+std::vector<unsigned char> hash(picosha2::k_digest_size);
 picosha2::hash256(std::istreambuf_iterator<char>(ifs), std::istreambuf_iterator<char>(), hash.begin(), hash.end());
 ```
 
@@ -88,14 +88,14 @@ std::string hash_hex_str = picosha2::hash256_hex_string(src_vect);
 ```
 
 ```c++
-unsigned char src_c_array[picosha2::KDigestSize] = {...};
+unsigned char src_c_array[picosha2::k_digest_size] = {...};
 std::string hash_hex_str;
-picosha2::hash256_hex_string(src_c_array, src_c_array+picosha2::KDigestSize, hash_hex_str);
+picosha2::hash256_hex_string(src_c_array, src_c_array+picosha2::k_digest_size, hash_hex_str);
 ```
 
 ```c++
-unsigned char src_c_array[picosha2::KDigestSize] = {...};
-std::string hash_hex_str = picosha2::hash256_hex_string(src_c_array, src_c_array+picosha2::KDigestSize);
+unsigned char src_c_array[picosha2::k_digest_size] = {...};
+std::string hash_hex_str = picosha2::hash256_hex_string(src_c_array, src_c_array+picosha2::k_digest_size);
 ```
 
 
@@ -106,7 +106,7 @@ std::string hash_hex_str = picosha2::hash256_hex_string(src_c_array, src_c_array
 std::string src_str = "The quick brown fox jumps over the lazy dog";
 
 //any STL sequantial containers (vector, list, dequeue...)
-std::vector<unsigned char> hash(picosha2::KDigestSize);
+std::vector<unsigned char> hash(picosha2::k_digest_size);
 
 // in: container, out: container
 picosha2::hash256(src_str, hash);
@@ -117,7 +117,7 @@ picosha2::hash256(src_str, hash);
 std::string src_str = "The quick brown fox jumps over the lazy dog";
 
 //any STL sequantial containers (vector, list, dequeue...)
-std::vector<unsigned char> hash(picosha2::KDigestSize);
+std::vector<unsigned char> hash(picosha2::k_digest_size);
 
 // in: iterator pair, out: contaner
 picosha2::hash256(src_str.begin(), src_str.end(), hash);
@@ -125,14 +125,14 @@ picosha2::hash256(src_str.begin(), src_str.end(), hash);
 
 ```c++
 std::string src_str = "The quick brown fox jumps over the lazy dog";
-unsigned char hash_byte_c_array[picosha2::KDigestSize];
+unsigned char hash_byte_c_array[picosha2::k_digest_size];
 // in: container, out: iterator(pointer) pair
-picosha2::hash256(src_str, hash_byte_c_array, hash_byte_c_array+picosha2::KDigestSize);
+picosha2::hash256(src_str, hash_byte_c_array, hash_byte_c_array+picosha2::k_digest_size);
 ```
 
 ```c++
 std::string src_str = "The quick brown fox jumps over the lazy dog";
-std::vector<unsigned char> hash(picosha2::KDigestSize);
+std::vector<unsigned char> hash(picosha2::k_digest_size);
 // in: iterator pair, out: iterator pair
 picosha2::hash256(src_str.begin(), src_str.end(), hash.begin(), hash.end());
 ```

--- a/picosha2.h
+++ b/picosha2.h
@@ -40,6 +40,8 @@ namespace picosha2 {
 typedef unsigned long word_t;
 typedef unsigned char byte_t;
 
+static const size_t KDigestSize = 32;
+
 namespace detail {
 inline byte_t mask_8bit(byte_t x) { return x & 0xff; }
 
@@ -271,9 +273,9 @@ class hash256_one_by_one {
 
 inline void get_hash_hex_string(const hash256_one_by_one& hasher,
                                 std::string& hex_str) {
-    byte_t hash[32];
-    hasher.get_hash_bytes(hash, hash + 32);
-    return bytes_to_hex_string(hash, hash + 32, hex_str);
+    byte_t hash[KDigestSize];
+    hasher.get_hash_bytes(hash, hash + KDigestSize);
+    return bytes_to_hex_string(hash, hash + KDigestSize, hex_str);
 }
 
 inline std::string get_hash_hex_string(const hash256_one_by_one& hasher) {
@@ -340,10 +342,10 @@ void hash256(const InContainer& src, OutContainer& dst) {
 
 template <typename InIter>
 void hash256_hex_string(InIter first, InIter last, std::string& hex_str) {
-    byte_t hashed[32];
-    hash256(first, last, hashed, hashed + 32);
+    byte_t hashed[KDigestSize];
+    hash256(first, last, hashed, hashed + KDigestSize);
     std::ostringstream oss;
-    output_hex(hashed, hashed + 32, oss);
+    output_hex(hashed, hashed + KDigestSize, oss);
     hex_str.assign(oss.str());
 }
 

--- a/picosha2.h
+++ b/picosha2.h
@@ -40,7 +40,7 @@ namespace picosha2 {
 typedef unsigned long word_t;
 typedef unsigned char byte_t;
 
-static const size_t KDigestSize = 32;
+static const size_t k_digest_size = 32;
 
 namespace detail {
 inline byte_t mask_8bit(byte_t x) { return x & 0xff; }
@@ -273,9 +273,9 @@ class hash256_one_by_one {
 
 inline void get_hash_hex_string(const hash256_one_by_one& hasher,
                                 std::string& hex_str) {
-    byte_t hash[KDigestSize];
-    hasher.get_hash_bytes(hash, hash + KDigestSize);
-    return bytes_to_hex_string(hash, hash + KDigestSize, hex_str);
+    byte_t hash[k_digest_size];
+    hasher.get_hash_bytes(hash, hash + k_digest_size);
+    return bytes_to_hex_string(hash, hash + k_digest_size, hex_str);
 }
 
 inline std::string get_hash_hex_string(const hash256_one_by_one& hasher) {
@@ -342,10 +342,10 @@ void hash256(const InContainer& src, OutContainer& dst) {
 
 template <typename InIter>
 void hash256_hex_string(InIter first, InIter last, std::string& hex_str) {
-    byte_t hashed[KDigestSize];
-    hash256(first, last, hashed, hashed + KDigestSize);
+    byte_t hashed[k_digest_size];
+    hash256(first, last, hashed, hashed + k_digest_size);
     std::ostringstream oss;
-    output_hex(hashed, hashed + KDigestSize, oss);
+    output_hex(hashed, hashed + k_digest_size, oss);
     hex_str.assign(oss.str());
 }
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -96,36 +96,36 @@ void test(){
         std::string src_str = sample_message_list[i].first;
         std::cout << "src_str: " << src_str  << " size: " << src_str.length() << std::endl;
         std::string ans_hex_str = sample_message_list[i].second;
-        std::vector<unsigned char> ans(32);
+        std::vector<unsigned char> ans(picosha2::k_digest_size);
         hex_string_to_bytes(ans_hex_str, ans);
         {
-            std::vector<unsigned char> hash(32);
+            std::vector<unsigned char> hash(picosha2::k_digest_size);
             picosha2::hash256(src_str.begin(), src_str.end(), hash.begin(), hash.end());
             PICOSHA2_CHECK_EQUAL_BYTES(ans, hash);
         }
         {
-            std::vector<unsigned char> hash(32);
+            std::vector<unsigned char> hash(picosha2::k_digest_size);
             picosha2::hash256(src_str, hash);
             PICOSHA2_CHECK_EQUAL_BYTES(ans, hash);
         }
         {
-            std::vector<unsigned char> hash(32);
+            std::vector<unsigned char> hash(picosha2::k_digest_size);
             picosha2::hash256(src_str.begin(), src_str.end(), hash);
             PICOSHA2_CHECK_EQUAL_BYTES(ans, hash);
         }
         {
-            unsigned char hash_c_array[32];
-            picosha2::hash256(src_str.begin(), src_str.end(), hash_c_array, hash_c_array+32);
-            std::vector<unsigned char> hash(hash_c_array, hash_c_array+32);
+            unsigned char hash_c_array[picosha2::k_digest_size];
+            picosha2::hash256(src_str.begin(), src_str.end(), hash_c_array, hash_c_array+picosha2::k_digest_size);
+            std::vector<unsigned char> hash(hash_c_array, hash_c_array+picosha2::k_digest_size);
             PICOSHA2_CHECK_EQUAL_BYTES(ans, hash);
         }
         {
-            std::list<unsigned char> hash(32);
+            std::list<unsigned char> hash(picosha2::k_digest_size);
             picosha2::hash256(src_str.begin(), src_str.end(), hash.begin(), hash.end());
             PICOSHA2_CHECK_EQUAL_BYTES(ans, hash);
         }
         {
-            std::list<unsigned char> hash(32);
+            std::list<unsigned char> hash(picosha2::k_digest_size);
             picosha2::hash256(src_str, hash);
             PICOSHA2_CHECK_EQUAL_BYTES(ans, hash);
         }
@@ -151,28 +151,28 @@ void test(){
         
         std::vector<unsigned char> src_vect(src_str.begin(), src_str.end());
         {
-            std::vector<unsigned char> hash(32);
+            std::vector<unsigned char> hash(picosha2::k_digest_size);
             picosha2::hash256(src_vect.begin(), src_vect.end(), hash.begin(), hash.end());
             PICOSHA2_CHECK_EQUAL_BYTES(ans, hash);
         }
         {
-            std::vector<unsigned char> hash(32);
+            std::vector<unsigned char> hash(picosha2::k_digest_size);
             picosha2::hash256(src_vect, hash);
             PICOSHA2_CHECK_EQUAL_BYTES(ans, hash);
         }
         {
-            std::list<unsigned char> hash(32);
+            std::list<unsigned char> hash(picosha2::k_digest_size);
             picosha2::hash256(src_vect.begin(), src_vect.end(), hash.begin(), hash.end());
             PICOSHA2_CHECK_EQUAL_BYTES(ans, hash);
         }
         {
-            std::list<unsigned char> hash(32);
+            std::list<unsigned char> hash(picosha2::k_digest_size);
             picosha2::hash256(src_vect.data(), src_vect.data()+src_vect.size(), 
                     hash.begin(), hash.end());
             PICOSHA2_CHECK_EQUAL_BYTES(ans, hash);
         }
         {
-            std::list<unsigned char> hash(32);
+            std::list<unsigned char> hash(picosha2::k_digest_size);
             picosha2::hash256(src_vect, hash);
             PICOSHA2_CHECK_EQUAL_BYTES(ans, hash);
         }
@@ -197,7 +197,7 @@ void test(){
         }
         {
             std::list<char> src(src_str.begin(), src_str.end());
-            std::vector<unsigned char> hash(32);
+            std::vector<unsigned char> hash(picosha2::k_digest_size);
             picosha2::hash256(src.begin(), src.end(), hash.begin(), hash.end());
             PICOSHA2_CHECK_EQUAL_BYTES(ans, hash);
         }


### PR DESCRIPTION
reasons:
- no magic numbers in the code
- better readability
- hide details from library consumers
- might be a bit easier to switch between hash functions