### PR TITLE
fix warning in vs2017

### DIFF
--- a/picosha2.h
+++ b/picosha2.h
@@ -192,7 +192,7 @@ class hash256_one_by_one {
 
     template <typename RaIter>
     void process(RaIter first, RaIter last) {
-        add_to_data_length(std::distance(first, last));
+        add_to_data_length(static_cast<word_t>(std::distance(first, last)));
         std::copy(first, last, std::back_inserter(buffer_));
         std::size_t i = 0;
         for (; i + 64 <= buffer_.size(); i += 64) {


### PR DESCRIPTION
Visual display this warning
warning C4244: 'argument': conversion from '__int64' to 'picosha2::word_t', possible loss of data"
a small static cast fix it